### PR TITLE
Fix csv export for multiline

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,4 +1,0 @@
-THELIA
-Copyright (C) 2005-2015 OpenStudio
-
-THELIA application uses externals components and libraries which are released under their own LGPL compatible license terms.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/core/lib/Thelia/Command/FrontTemplate.php
+++ b/core/lib/Thelia/Command/FrontTemplate.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Thelia\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Thelia\Model\ConfigQuery;
+
+/**
+* change the front template
+*
+* Class FrontTemplate
+* @package Thelia\Command
+* @author Damien Foulhoux <dfoulhoux@openstudio.fr>
+*
+*/
+class FrontTemplate extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+        ->setName("template:front")
+        ->setDescription("set front template")
+        ->addArgument(
+            "template",
+            InputArgument::REQUIRED,
+            "template to activate"
+        );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $template = $input->getArgument("template");
+        
+        $templateExists = is_dir(THELIA_TEMPLATE_DIR  . 'frontOffice' . DS . $template);
+
+        if ($templateExists) {
+            ConfigQuery::write('active-front-template', $template);
+        }
+    }
+}

--- a/core/lib/Thelia/Config/Resources/command.xml
+++ b/core/lib/Thelia/Config/Resources/command.xml
@@ -28,6 +28,7 @@
         <command class="Thelia\Command\ImportCommand"/>
         <command class="Thelia\Command\UpdateCurrenciesRates"/>
         <command class="Thelia\Command\DiffDatabaseCommand"/>
+        <command class="Thelia\Command\FrontTemplate"/>
     </commands>
 
 </config>

--- a/core/lib/Thelia/Core/Event/Delivery/DeliveryPostageEvent.php
+++ b/core/lib/Thelia/Core/Event/Delivery/DeliveryPostageEvent.php
@@ -267,8 +267,8 @@ class DeliveryPostageEvent extends ActionEvent
      */
     public function setDeliveryMode($deliveryMode)
     {
-        if (!in_array($deliveryMode, ['pickup', 'delivery'])) {
-            throw new \Exception(Translator::getInstance()->trans('A delivery module can only de of type pickup or delivery'));
+        if (!in_array($deliveryMode, ['delivery', 'pickup', 'localPickup'])) {
+            throw new \Exception(Translator::getInstance()->trans('A delivery module can only be of type "delivery", "pickup" or "localPickup".'));
         }
 
         $this->deliveryMode = $deliveryMode;

--- a/core/lib/Thelia/Core/EventListener/RequestListener.php
+++ b/core/lib/Thelia/Core/EventListener/RequestListener.php
@@ -35,6 +35,7 @@ use Thelia\Model\AdminLog;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Currency;
 use Thelia\Model\CurrencyQuery;
+use Thelia\Model\Customer;
 use Thelia\Model\Lang;
 use Thelia\Model\LangQuery;
 use Thelia\Tools\RememberMeTrait;
@@ -106,7 +107,7 @@ class RequestListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
         if (!\count($request->request->all()) && \in_array($request->getMethod(), array('POST', 'PUT', 'PATCH', 'DELETE'))) {
-            if ('json' == $request->getFormat($request->headers->get('Content-Type'))) {
+            if ('json' === $request->getFormat($request->headers->get('Content-Type'))) {
                 $content = $request->getContent();
                 if (!empty($content)) {
                     $data = json_decode($content, true);
@@ -119,7 +120,9 @@ class RequestListener implements EventSubscriberInterface
                         $event->stopPropagation();
 
                         return;
-                    } elseif (!\is_array($data)) {
+                    }
+
+                    if (!\is_array($data)) {
                         // This case happens for string like: "Foo", that json_decode returns as valid json
                         $data = [$data];
                     }
@@ -150,6 +153,7 @@ class RequestListener implements EventSubscriberInterface
 
             try {
                 // If have found a user, store it in the security context
+                /** @var Customer $user */
                 $user = $authenticator->getAuthentifiedUser();
 
                 $session->setCustomerUser($user);
@@ -208,7 +212,7 @@ class RequestListener implements EventSubscriberInterface
         if (null === $lang = LangQuery::create()
                 ->filterByActive(true)
                 ->filterByLocale($locale)
-                ->findOne($locale)) {
+                ->findOne()) {
             $lang = Lang::getDefaultLanguage();
         }
 
@@ -236,7 +240,7 @@ class RequestListener implements EventSubscriberInterface
 
             if (null !== $referrer) {
                 // A previous URL (or the keyword 'dont-save') has been specified.
-                if ('dont-save' == $referrer) {
+                if ('dont-save' === $referrer) {
                     // We should not save the current URL as the previous URL
                     $referrer = null;
                 }

--- a/core/lib/Thelia/Core/Serializer/Serializer/CSVSerializer.php
+++ b/core/lib/Thelia/Core/Serializer/Serializer/CSVSerializer.php
@@ -134,24 +134,31 @@ class CSVSerializer extends AbstractSerializer
 
         clearstatcache(true, $fileObject->getPathname());
     }
-
+    
+    
     public function unserialize(\SplFileObject $fileObject)
     {
         $data = [];
 
-        foreach ($fileObject as $index => $row) {
+        $index = 0;
+        while(null !== $row = $fileObject->fgetcsv($this->delimiter, $this->enclosure)) {
+            $index++;
             if (empty($row)) {
                 continue;
             }
 
-            if ($index === 0) {
-                $this->headers = str_getcsv($row, $this->delimiter, $this->enclosure);
+            if ($index === 1) {
+                $this->headers = $row;
+                continue;
+            }
+
+            if (count($row) !== count($this->headers)) {
                 continue;
             }
 
             $data[] = array_combine(
                 $this->headers,
-                str_getcsv($row, $this->delimiter, $this->enclosure)
+                $row
             );
         }
 

--- a/core/lib/Thelia/Handler/ExportHandler.php
+++ b/core/lib/Thelia/Handler/ExportHandler.php
@@ -182,11 +182,15 @@ class ExportHandler
             );
         }
         if ($rangeDate['end'] && !($rangeDate['end'] instanceof \DateTime)) {
+            // To get the last day of selected month, go to the first day of next month and substract 1 day
             $rangeDate['end'] = \DateTime::createFromFormat(
                 'Y-m-d H:i:s',
-                $rangeDate['end']['year'] . '-' . (\intval($rangeDate['end']['month']) + 1) . '-0 23:59:59'
-            );
+                $rangeDate['end']['year'] . '-' . $rangeDate['end']['month'] . '-1 23:59:59'
+            )
+            ->add(new \DateInterval('P1M'))
+            ->sub(new \DateInterval('P1D'));
         }
+
         $instance->setRangeDate($rangeDate);
 
         // Process export

--- a/core/lib/Thelia/ImportExport/Export/Type/MailingExport.php
+++ b/core/lib/Thelia/ImportExport/Export/Type/MailingExport.php
@@ -29,7 +29,8 @@ class MailingExport extends JsonFileAbstractExport
         'newsletter_id' => 'Identifier',
         'newsletter_email' => 'Email',
         'newsletter_firstname' => 'FirstName',
-        'newsletter_lastname' => 'LastName'
+        'newsletter_lastname' => 'LastName',
+        'newsletter_locale' => 'Locale'
     ];
 
     protected function getData()
@@ -39,7 +40,8 @@ class MailingExport extends JsonFileAbstractExport
                         newsletter.id as "newsletter_id",
                         newsletter.email as "newsletter_email", 
                         newsletter.firstname as "newsletter_firstname", 
-                        newsletter.lastname as "newsletter_lastname"
+                        newsletter.lastname as "newsletter_lastname",
+                        newsletter.locale as "newsletter_locale"
                     FROM newsletter
                     WHERE newsletter.unsubscribed = 0'
         ;

--- a/core/lib/Thelia/ImportExport/Export/Type/OrderExport.php
+++ b/core/lib/Thelia/ImportExport/Export/Type/OrderExport.php
@@ -161,8 +161,8 @@ class OrderExport extends JsonFileAbstractExport
 
         $stmt = $con->prepare($query);
         $stmt->bindValue('locale', $locale);
-        $stmt->bindValue('start', $this->rangeDate['start']->format('Y-m-d'));
-        $stmt->bindValue('end', $this->rangeDate['end']->format('Y-m-d'));
+        $stmt->bindValue('start', $this->rangeDate['start']->format('Y-m-d H:i:s'));
+        $stmt->bindValue('end', $this->rangeDate['end']->format('Y-m-d H:i:s'));
         $stmt->execute();
 
         $filename = THELIA_CACHE_DIR . '/export/' . 'order.json';


### PR DESCRIPTION
When you want export csv with a content that contains some new line character the serializer with `foreach ($fileObject as $index => $row) {` will count each lines as row.

With `$fileObject->fgetcsv($this->delimiter, $this->enclosure)` a row is a csv line and not file line.